### PR TITLE
Crash on restart fix

### DIFF
--- a/src/android/ParsePushNotificationPlugin.java
+++ b/src/android/ParsePushNotificationPlugin.java
@@ -89,7 +89,7 @@ public class ParsePushNotificationPlugin extends CordovaPlugin {
 
 			return true;
 		}			
-/*		
+/*		ge
 		else if (action.equals("registerAsPushNotificationClient")) {
 			registerAsPushNotificationClient(action, args, callbackContext);
 			
@@ -200,7 +200,7 @@ public class ParsePushNotificationPlugin extends CordovaPlugin {
 
        try {
             if (!ParsePushNotificationPlugin.isInitialized()) {
-               	Parse.initialize(cordova.getActivity(), applicationId, clientKey);
+               	Parse.initialize(cordova.getActivity().getApplication(), applicationId, clientKey);
         	   	ParseInstallation.getCurrentInstallation().save();
                 ParsePushNotificationPlugin.setInitialized();
 


### PR DESCRIPTION
The app was crashing on restart and giving me this error  
<code> Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.Context com.parse.ParsePlugins$Android.applicationContext()' on a null object reference </code>. 

This fixes the issue . 

Source:- http://stackoverflow.com/questions/32075789/app-crashes-on-parse-push-notification-when-the-app-is-not-running
